### PR TITLE
More settings

### DIFF
--- a/resources/ClassicAxisIII.ini
+++ b/resources/ClassicAxisIII.ini
@@ -7,8 +7,6 @@ LockOnTargetType = 1
 ShowTriangleForMouseRecruit = true
 ; Makes the player walk using the defined keyboard key (NULL to disable).
 WalkKey = LALT
-; Makes camera while aiming similar to LCS/VCS.
-StoriesAimingCoords = false
 ; Crosshair position from (0.0f - 1.0f) while aiming in third person (default 0.53f, 0.4f).
 CameraCrosshairMultX = 0.53f
 CameraCrosshairMultY = 0.4f

--- a/resources/ClassicAxisIII.ini
+++ b/resources/ClassicAxisIII.ini
@@ -19,3 +19,11 @@ RightAnalogStickSensitivityX = 1.0f
 RightAnalogStickSensitivityY = 1.0f
 ; Makes the player crouch using the defined keyboard key (NULL to disable).
 CrouchKey = C
+; Speed of transition to aiming mode (time in ms, 500 = default).
+TransitionSpeed = 150
+; Choose aiming coordinates (0 = SA, 1 = LCS/VCS, 2 = Custom).
+AimingCoords = 2
+; Custom aiming coordinates (see AimingCoords).
+AimingCoordsX = -0.8f
+AimingCoordsY = 0.0f
+AimingCoordsZ = 0.0f

--- a/resources/ClassicAxisIII.ini
+++ b/resources/ClassicAxisIII.ini
@@ -20,10 +20,10 @@ RightAnalogStickSensitivityY = 1.0f
 ; Makes the player crouch using the defined keyboard key (NULL to disable).
 CrouchKey = C
 ; Speed of transition to aiming mode (time in ms, 500 = default).
-TransitionSpeed = 150
+TransitionSpeed = 500
 ; Choose aiming coordinates (0 = SA, 1 = LCS/VCS, 2 = Custom).
-AimingCoords = 2
+AimingCoords = 0
 ; Custom aiming coordinates (see AimingCoords).
-AimingCoordsX = -0.8f
+AimingCoordsX = 0.0f
 AimingCoordsY = 0.0f
 AimingCoordsZ = 0.0f

--- a/resources/ClassicAxisVC.ini
+++ b/resources/ClassicAxisVC.ini
@@ -7,8 +7,6 @@ LockOnTargetType = 1
 ShowTriangleForMouseRecruit = true
 ; Makes the player walk using the defined keyboard key (NULL to disable).
 WalkKey = LALT
-; Makes camera while aiming similar to LCS/VCS.
-StoriesAimingCoords = false
 ; Crosshair position from (0.0f - 1.0f) while aiming in third person (default 0.53f, 0.4f).
 CameraCrosshairMultX = 0.53f
 CameraCrosshairMultY = 0.4f
@@ -19,3 +17,11 @@ RightAnalogStickSensitivityX = 1.0f
 RightAnalogStickSensitivityY = 1.0f
 ; Decrease FOV automatically while aiming with an assault rifle.
 ZoomForAssaultRifles = false
+; Speed of transition to aiming mode (time in ms, 500 = default).
+TransitionSpeed = 150
+; Choose aiming coordinates (0 = SA, 1 = LCS/VCS, 2 = Custom).
+AimingCoords = 2
+; Custom aiming coordinates (see AimingCoords).
+AimingCoordsX = -0.8f
+AimingCoordsY = 0.0f
+AimingCoordsZ = 0.0f

--- a/resources/ClassicAxisVC.ini
+++ b/resources/ClassicAxisVC.ini
@@ -18,10 +18,10 @@ RightAnalogStickSensitivityY = 1.0f
 ; Decrease FOV automatically while aiming with an assault rifle.
 ZoomForAssaultRifles = false
 ; Speed of transition to aiming mode (time in ms, 500 = default).
-TransitionSpeed = 150
+TransitionSpeed = 500
 ; Choose aiming coordinates (0 = SA, 1 = LCS/VCS, 2 = Custom).
-AimingCoords = 2
+AimingCoords = 0
 ; Custom aiming coordinates (see AimingCoords).
-AimingCoordsX = -0.8f
+AimingCoordsX = 0.0f
 AimingCoordsY = 0.0f
 AimingCoordsZ = 0.0f

--- a/source/CamNew.cpp
+++ b/source/CamNew.cpp
@@ -230,10 +230,12 @@ void CCamNew::Process_AimWeapon(CVector const& target, float targetOrient, float
 
     CVector aimOffset;
     
-    if (classicAxis.settings.storiesAimingCoords)
-        aimOffset = CVector(0.55f, 0.0f, 0.0f);
-    else
+    if (classicAxis.settings.aimingCoords == COORDS_SA)
         aimOffset = CVector(0.2f, 0.0f, 0.0f);
+    else if (classicAxis.settings.aimingCoords == COORDS_STORIES)
+        aimOffset = CVector(0.55f, 0.0f, 0.0f);
+    else if (classicAxis.settings.aimingCoords == COORDS_CUSTOM)
+        aimOffset = CVector(classicAxis.settings.aimingCoordsX, classicAxis.settings.aimingCoordsY, classicAxis.settings.aimingCoordsZ);
 
 #ifdef GTA3
     CMatrix& mat = e->m_matrix;

--- a/source/ClassicAxis.cpp
+++ b/source/ClassicAxis.cpp
@@ -207,7 +207,7 @@ ClassicAxis::ClassicAxis() {
     onStartingTransition.after += [](CCam* cam, short mode) {
         if (mode == MODE_AIMWEAPON || mode == MODE_FOLLOW_PED) {
             if (classicAxis.switchTransitionSpeed) {
-                const int transitionDuration = 500;
+                const int transitionDuration = classicAxis.settings.transitionSpeed;
 
                 TheCamera.m_nTransitionDuration = transitionDuration;
 #ifdef GTAVC

--- a/source/Settings.cpp
+++ b/source/Settings.cpp
@@ -12,13 +12,17 @@ void Settings::Read() {
     lockOnTargetType = config["LockOnTargetType"].asInt(TARGET_SA);
     showTriangleForMouseRecruit = config["ShowTriangleForMouseRecruit"].asBool(true);
     walkKey = config["WalkKey"].asString("LALT");
-    storiesAimingCoords = config["StoriesAimingCoords"].asBool(false);
     cameraCrosshairMultX = config["CameraCrosshairMultX"].asFloat(0.53f);
     cameraCrosshairMultY = config["CameraCrosshairMultY"].asFloat(0.4f);
     storiesPointingArm = config["StoriesPointingArm"].asBool(false);
     rightAnalogStickSensitivityX = config["RightAnalogStickSensitivityX"].asFloat(1.0f);
     rightAnalogStickSensitivityY = config["RightAnalogStickSensitivityY"].asFloat(1.0f);
     zoomForAssaultRifles = config["ZoomForAssaultRifles"].asBool(true);
+    aimingCoords = config["AimingCoords"].asInt(COORDS_SA);
+    aimingCoordsX = config["AimingCoordsX"].asFloat(0.0f);
+    aimingCoordsY = config["AimingCoordsY"].asFloat(0.0f);
+    aimingCoordsZ = config["AimingCoordsZ"].asFloat(0.0f);
+    transitionSpeed = config["TransitionSpeed"].asInt(500);
 
 #ifdef GTA3
     crouchKey = config["CrouchKey"].asString("C");

--- a/source/Settings.h
+++ b/source/Settings.h
@@ -6,13 +6,23 @@ enum eLockOnTargetType {
     TARGET_LCS
 };
 
+enum eAimingCoords {
+    COORDS_SA,
+    COORDS_STORIES,
+    COORDS_CUSTOM
+};
+
 class Settings {
 public:
     bool forceAutoAim;
     int lockOnTargetType;
     bool showTriangleForMouseRecruit;
     std::string walkKey;
-    bool storiesAimingCoords;
+    int transitionSpeed;
+    float aimingCoordsX;
+    float aimingCoordsY;
+    float aimingCoordsZ;
+    int aimingCoords;
     float cameraCrosshairMultX;
     float cameraCrosshairMultY;
     bool storiesPointingArm;


### PR DESCRIPTION
This adds 5 new options to be customized in the ini file. They are: TransitionSpeed, AimingCoords, AimingCoordsX, AimingCoordsY, AimingCoordsZ. TransitionSpeed can change the time it takes for the camera to switch to aiming. The default value is 500. AimingCoords can change the camera position during aiming to SA style (value: 0), Stories style (value: 1) or Custom (value: 2). The default value is SA style and the custom option uses float values from AimingCoordsX, AimingCoordsY, AimingCoordsZ to change camera position. I don't have a lot of coding experience, but these changes worked fine on both GTA III and VC for me. If you have any suggestions or improvements for this, please tell me.