### PR TITLE
Added option to disable auto aim while playing with a controller

### DIFF
--- a/resources/ClassicAxisIII.ini
+++ b/resources/ClassicAxisIII.ini
@@ -1,6 +1,8 @@
 [ClassicAxis]
 ; Force auto aim while playing with keyboard and mouse.
 ForceAutoAim = false
+; Disables auto aim while playing with a controller.
+DisableAutoAimOnController = false
 ; Choose the lock on target to display while auto aiming (0 = default, 1 = SA, 2 = LCS/VCS).
 LockOnTargetType = 1
 ; While aiming with mouse, displays a triangle with the color of the health over the head of the pedestrian.

--- a/resources/ClassicAxisVC.ini
+++ b/resources/ClassicAxisVC.ini
@@ -1,6 +1,8 @@
 [ClassicAxis]
 ; Force auto aim while playing with keyboard and mouse.
 ForceAutoAim = false
+; Disables auto aim while playing with a controller.
+DisableAutoAimOnController = false
 ; Choose the lock on target to display while auto aiming (0 = default, 1 = SA, 2 = LCS/VCS).
 LockOnTargetType = 1
 ; While aiming with mouse, displays a triangle with the color of the health over the head of the pedestrian.

--- a/source/ClassicAxis.cpp
+++ b/source/ClassicAxis.cpp
@@ -18,6 +18,10 @@
 #include "CamNew.h"
 #include "CDraw.h"
 
+#ifdef GTA3
+#include "RpAnimBlend.h"
+#endif
+
 ClassicAxis classicAxis;
 
 ClassicAxis::ClassicAxis() {
@@ -589,8 +593,13 @@ bool ClassicAxis::IsAbleToAim(CPed* ped) {
     const eWeaponType weaponType = ped->m_aWeapons[ped->m_nCurrentWeapon].m_eWeaponType;
     CWeaponInfo* info = CWeaponInfo::GetWeaponInfo(weaponType);
 
+#ifdef GTA3
+    if (weaponType == WEAPONTYPE_UNARMED)
+        return false;
+#else
     if (weaponType == WEAPONTYPE_UNARMED || weaponType == WEAPONTYPE_BRASSKNUCKLE)
         return false;
+#endif
 
     switch (s) {
     case PEDSTATE_NONE:
@@ -630,8 +639,13 @@ bool ClassicAxis::IsWeaponPossiblyCompatible(CPed* ped) {
     const eWeaponType weaponType = ped->m_aWeapons[ped->m_nCurrentWeapon].m_eWeaponType;
     CWeaponInfo* info = CWeaponInfo::GetWeaponInfo(weaponType);
 
+#ifdef GTA3
+    if (weaponType == WEAPONTYPE_UNARMED)
+        return false;
+#else
     if (weaponType == WEAPONTYPE_UNARMED || weaponType == WEAPONTYPE_BRASSKNUCKLE)
         return false;
+#endif
 
     switch (weaponType) {
     case WEAPONTYPE_FLAMETHROWER:
@@ -665,8 +679,13 @@ bool ClassicAxis::CanDuckWithThisWeapon(eWeaponType weapon) {
 bool ClassicAxis::IsTypeMelee(CPed* ped) {
     const eWeaponType weaponType = ped->m_aWeapons[ped->m_nCurrentWeapon].m_eWeaponType;
 
+#ifdef GTA3
+    if (weaponType == WEAPONTYPE_UNARMED)
+        return false;
+#else
     if (weaponType == WEAPONTYPE_UNARMED || weaponType == WEAPONTYPE_BRASSKNUCKLE)
-        return true;
+        return false;
+#endif
 
 #ifdef GTA3
     switch (weaponType) {
@@ -689,8 +708,13 @@ bool ClassicAxis::IsTypeTwoHanded(CPed* ped) {
     const eWeaponType weaponType = ped->m_aWeapons[ped->m_nCurrentWeapon].m_eWeaponType;
     CWeaponInfo* info = CWeaponInfo::GetWeaponInfo(weaponType);
 
+#ifdef GTA3
+    if (weaponType == WEAPONTYPE_UNARMED)
+        return false;
+#else
     if (weaponType == WEAPONTYPE_UNARMED || weaponType == WEAPONTYPE_BRASSKNUCKLE)
         return false;
+#endif
 
     switch (weaponType) {
     case WEAPONTYPE_FLAMETHROWER:

--- a/source/ClassicAxis.cpp
+++ b/source/ClassicAxis.cpp
@@ -302,7 +302,10 @@ ClassicAxis::ClassicAxis() {
     plugin::Events::drawHudEvent += [] {
         classicAxis.DrawCrosshair();
 
-        bool disableAutoAim = !classicAxis.pXboxPad->HasPadInHands() && !classicAxis.settings.forceAutoAim;
+        bool hasPadInHands = classicAxis.pXboxPad->HasPadInHands();
+        bool disableAutoAim = !hasPadInHands && !classicAxis.settings.forceAutoAim ||
+            hasPadInHands && classicAxis.settings.disableAutoAimOnController;
+
         if (!disableAutoAim)
             classicAxis.DrawAutoAimTarget();
 
@@ -447,7 +450,10 @@ ClassicAxis::ClassicAxis() {
     plugin::ThiscallEvent <plugin::AddressList<0x534D64, plugin::H_CALL>, plugin::PRIORITY_AFTER, plugin::ArgPickN<CPlayerPed*, 0>, void(CPlayerPed*)> onFindingLockOnTarget;
 #endif
     onFindingLockOnTarget += [](CPlayerPed* ped) {
-        bool disableAutoAim = !classicAxis.pXboxPad->HasPadInHands() && !classicAxis.settings.forceAutoAim;
+        bool hasPadInHands = classicAxis.pXboxPad->HasPadInHands();
+        bool disableAutoAim = !hasPadInHands && !classicAxis.settings.forceAutoAim ||
+            hasPadInHands && classicAxis.settings.disableAutoAimOnController;
+
         if (disableAutoAim || 
             (ped->m_pPointGunAt && !ped->m_pPointGunAt->GetIsOnScreenComplex()))
             ped->ClearWeaponTarget();
@@ -1203,7 +1209,9 @@ void ClassicAxis::ProcessPlayerPedControl(CPlayerPed* playa) {
         CEntity* p = playa->m_pPointGunAt;
         float mouseX = pad->NewMouseControllerState.x;
         float mouseY = pad->NewMouseControllerState.y;
-        bool disableAutoAim = !hasPadInHands && !settings.forceAutoAim;
+
+        bool disableAutoAim = !hasPadInHands && !classicAxis.settings.forceAutoAim ||
+            hasPadInHands && classicAxis.settings.disableAutoAimOnController;
 
         if (!disableAutoAim) {
             if (playa->m_bHasLockOnTarget && p) {

--- a/source/Settings.cpp
+++ b/source/Settings.cpp
@@ -9,6 +9,7 @@ void Settings::Read() {
 #endif
 
     forceAutoAim = config["ForceAutoAim"].asBool(false);
+    disableAutoAimOnController = config["DisableAutoAimOnController"].asBool(false);
     lockOnTargetType = config["LockOnTargetType"].asInt(TARGET_SA);
     showTriangleForMouseRecruit = config["ShowTriangleForMouseRecruit"].asBool(true);
     walkKey = config["WalkKey"].asString("LALT");

--- a/source/Settings.h
+++ b/source/Settings.h
@@ -9,6 +9,7 @@ enum eLockOnTargetType {
 class Settings {
 public:
     bool forceAutoAim;
+    bool disableAutoAimOnController;
     int lockOnTargetType;
     bool showTriangleForMouseRecruit;
     std::string walkKey;


### PR DESCRIPTION
I like playing GTA Vice City with a controller. What i don't like is when the game messes with the camera while i'm trying to aim, especially when the game thinks it's doing me a favor by aiming for, say, a rioter when i'm trying to shoot a gas task.

I was surprised to find that your mod offers the option to enable auto aim for keyboard and mouse gameplay but not the opposite option for controllers.

So i decided to fix that. Unfortunately people don't get scared anymore when i hold them at gunpoint anymore but thanks to violence in movies and sex on TV they were bound to get desensitized anyway, right?