### PR TITLE
Fix NULL vftable crash during game state init in Process_AvoidCollisions

### DIFF
--- a/source/CamNew.cpp
+++ b/source/CamNew.cpp
@@ -53,7 +53,7 @@ void CCamNew::Process_FollowPed(CVector const& target, float targetOrient, float
     if (!cam)
         return;
 
-    if (cam->m_pCamTargetEntity->m_nType != ENTITY_TYPE_PED)
+    if (!cam->m_pCamTargetEntity || cam->m_pCamTargetEntity->m_nType != ENTITY_TYPE_PED)
         return;
 
     CPed* e = static_cast<CPed*>(cam->m_pCamTargetEntity);
@@ -234,7 +234,7 @@ void CCamNew::Process_AimWeapon(CVector const& target, float targetOrient, float
     if (!cam)
         return;
 
-    if (cam->m_pCamTargetEntity->m_nType != ENTITY_TYPE_PED)
+    if (!cam->m_pCamTargetEntity || cam->m_pCamTargetEntity->m_nType != ENTITY_TYPE_PED)
         return;
 
     doFovChanges = true;
@@ -418,6 +418,8 @@ void CCamNew::Process_AvoidCollisions(float length) {
         float radius = (viewPlaneWidth * nearClip);
         CVector center = cam->m_vecSource + cam->m_vecFront * nearClip;
         if (entity = CWorld::TestSphereAgainstWorld(center, radius, NULL, true, true, true, true, false, true)) {
+            // FIX: skip if entity has NULL vftable (object exists but not constructed - crashes virtual calls below)
+            if (!entity || *reinterpret_cast<void**>(entity) == nullptr) continue;
             bool isTypePed = entity->m_nType == ENTITY_TYPE_PED;
 
             if (isTypePed && entity->IsVisible() && Magnitude2d((center - entity->GetPosition())) < 0.5f) {


### PR DESCRIPTION
CWorld::TestSphereAgainstWorld can return an entity pointer that is allocated but not yet fully constructed (vftable still NULL) during early game-state initialization. The subsequent entity->IsVisible() virtual call dereferences the NULL vftable and crashes.

Field accesses like entity->m_nType (line 394) at non-zero offsets succeed because the underlying memory is valid - only the vftable pointer at offset 0 is uninitialized. This makes the crash specific to the virtual call on line 396 (entity->IsVisible).

Reproduction: starting a new game on a clean 1.0 EN exe with only GInput + Classic AXIS active crashes deterministically at AXIS RVA 0x20B39 (access violation reading 0x00000000, ECX loaded NULL from the vftable pointer just before the virtual dispatch).

Fix: defensively skip the iteration when entity is NULL or has a NULL vftable. Also adds NULL guards on cam->m_pCamTargetEntity in Process_FollowPed and Process_AimWeapon, where the same class of issue can occur (m_pCamTargetEntity is not always set during init).